### PR TITLE
ShibokenGenerator: Don't scope pointer default values

### DIFF
--- a/generator/shiboken2/shibokengenerator.cpp
+++ b/generator/shiboken2/shibokengenerator.cpp
@@ -417,8 +417,12 @@ static QString searchForEnumScope(const AbstractMetaClass* metaClass, const QStr
 QString ShibokenGenerator::guessScopeForDefaultValue(const AbstractMetaFunction* func, const AbstractMetaArgument* arg)
 {
     QString value = getDefaultValue(func, arg);
+
     if (value.isEmpty())
         return QString();
+
+    if (isPointer(arg->type()))
+        return value;
 
     static QRegExp enumValueRegEx("^([A-Za-z_]\\w*)?$");
     QString prefix;


### PR DESCRIPTION
This was causing an error when generating the wrapper for
QJsonDocument::fromJson(). There, the default value for
the last argument,

    	 QJsonParseError *error = Q_NULLPTR

would be QJsonParseError::NULL which is wrong. Other cases
may occur, but nothing we did detect since the build was
failing at that stage.